### PR TITLE
Removed explicit /wiki context path from client.rb and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Or install it yourself as:
     username = 'username'
     password = 'password'
     space    = 'Home'
-    url      = 'https://company.atlassian.net'
+    url      = 'https://company.atlassian.net/wiki'
+
+    # Note: url is automatically appended with /rest/api/content so if your
+    #       Confluence base URL is different from "/wiki" specify it above
 
     client = Confluence::Api::Client.new(username, password, url)
     page = client.get({spaceKey: space, title: 'September'})[0]

--- a/lib/confluence/api/client.rb
+++ b/lib/confluence/api/client.rb
@@ -19,13 +19,13 @@ module Confluence
       end
 
       def get(params)
-        response = conn.get('/wiki/rest/api/content', params)
+        response = conn.get('/rest/api/content', params)
         JSON.parse(response.body)['results']
       end
 
       def create(params)
         response = conn.post do |req|
-          req.url '/wiki/rest/api/content'
+          req.url '/rest/api/content'
           req.headers['Content-Type'] = 'application/json'
           req.body = params.to_json
         end
@@ -34,7 +34,7 @@ module Confluence
 
       def update(id, params)
         response = conn.put do |req|
-          req.url "/wiki/rest/api/content/#{id}"
+          req.url "/rest/api/content/#{id}"
           req.headers['Content-Type'] = 'application/json'
           req.body = params.to_json
         end


### PR DESCRIPTION
Hi @amishyn 

Not all Confluence systems use /wiki in the context path - in our deployment, the context path for the API is /rest/api/content (without /wiki) - please consider this patch as a more flexible way of defining the base URL / context path to the REST API.